### PR TITLE
Derive `MonoidStruct` for `Term`.

### DIFF
--- a/src/SOAS.idr
+++ b/src/SOAS.idr
@@ -151,6 +151,13 @@ record (.PointedCoalgStruct) type (x : type.SortedFamily) where
   ren : x -|> [] x
   var : Var -|> x
 
+%hint
+(.VarPointedCoalgStruct) : (0 type : Type) -> type.PointedCoalgStruct Var
+type.VarPointedCoalgStruct = MkPointedCoalgStruct
+  { ren = \i, f => f i
+  , var = id
+  }
+
 liftPos : (ctx : type.Ctx) -> (mon : type.PointedCoalgStruct p) =>
   {ctx2 : type.Ctx} ->
   (p.subst ctx1 ctx2) -> p.substNamed (ctx1 ++ ctx) (ctx2 ++ ctx)

--- a/src/SOAS.idr
+++ b/src/SOAS.idr
@@ -136,12 +136,12 @@ record MonStruct (m : type.SortedFamily) where
   var : Var -|> m
   mult : m -|> (m ^ m)
 
-(.sub) : {m : type.SortedFamily} -> {ty,sy : type} -> {ctx : type.Ctx} ->
+(.sub) : {m : type.SortedFamily} -> {ty,sy : type} -> {0 ctx : type.Ctx} ->
   (mon : MonStruct m) => m sy (ctx :< (n :- ty)) -> m ty ctx -> m sy ctx
 t.sub s = mon.mult t (extend m s mon.var)
 
 (.sub2) : {m : type.SortedFamily} -> {ty1,ty2,sy : type} ->
-  {ctx : type.Ctx} ->
+  {0 ctx : type.Ctx} ->
   (mon : MonStruct m) => m sy (ctx :< (x :- ty1) :< (x :- ty2)) ->
   m ty1 ctx ->  m ty2 ctx -> m sy ctx
 t.sub2 s1 s2 = mon.mult t (extend m s2 (extend m s1 mon.var))

--- a/src/SOAS.idr
+++ b/src/SOAS.idr
@@ -111,16 +111,16 @@ extend x {ctx2, ty} u theta =
 (src -<> tgt) ty ctx = {0 ctx' : type.Ctx} -> src ty ctx' ->
   tgt ty (ctx ++ ctx')
 
-0
-Nil : type.SortedFamily -> type.SortedFamily
-Nil f ty ctx = {0 ctx' : type.Ctx} -> ctx ~> ctx' -> f ty ctx'
-
 -- TODO: (Setoid) coalgebras
 
 0
 (^) : (tgt, src : type.SortedFamily) -> type.SortedFamily
 (tgt ^ src) ty ctx =
   {0 ctx' : type.Ctx} -> src.subst ctx ctx' -> tgt ty ctx'
+
+0
+Nil : type.SortedFamily -> type.SortedFamily
+Nil f = f ^ Var
 
 hideCtx : {0 a : type.Ctx -> Type} ->
   ((0 ctx : type.Ctx) -> a ctx) -> {ctx : type.Ctx} -> a ctx


### PR DESCRIPTION
Uses traversal to generate `MonoidStruct` for `Term`. This fills in the missing right-hand side for `beta`.

In exchange, `Map` and `Strength` are now singleton records. This helps with automatic search so we no longer need to explicitly pass around `str` and `functoriality`. 